### PR TITLE
[#20] Task 등록, 수정, 삭제 기능에 Reminder 설정 기능 추가

### DIFF
--- a/api/src/main/java/com/taskbuddy/api/controller/TaskController.java
+++ b/api/src/main/java/com/taskbuddy/api/controller/TaskController.java
@@ -70,6 +70,7 @@ public class TaskController {
                 request.title(),
                 request.description(),
                 true,
+                Duration.ofMinutes(10),
                 request.timeFrame().startDateTime(),
                 request.timeFrame().endDateTime());
         taskService.updateContent(taskContentUpdate);

--- a/api/src/main/java/com/taskbuddy/api/controller/TaskController.java
+++ b/api/src/main/java/com/taskbuddy/api/controller/TaskController.java
@@ -16,6 +16,7 @@ import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.Duration;
 
 @RequiredArgsConstructor
 @RequestMapping("/v1/tasks")
@@ -43,6 +44,8 @@ public class TaskController {
                 dummyUserId,
                 request.title(),
                 request.description(),
+                true,
+                Duration.ofMinutes(10),
                 request.timeFrame().startDateTime(),
                 request.timeFrame().endDateTime()
         );
@@ -66,6 +69,7 @@ public class TaskController {
                 dummyUserId,
                 request.title(),
                 request.description(),
+                true,
                 request.timeFrame().startDateTime(),
                 request.timeFrame().endDateTime());
         taskService.updateContent(taskContentUpdate);

--- a/core/src/main/java/com/taskbuddy/core/database/entity/TaskEntity.java
+++ b/core/src/main/java/com/taskbuddy/core/database/entity/TaskEntity.java
@@ -28,18 +28,21 @@ public class TaskEntity {
 
     private LocalDateTime endDateTime;
 
+    private Boolean isReminderEnabled;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
 
     @Builder
-    private TaskEntity(Long id, String title, Boolean isDone, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private TaskEntity(Long id, String title, Boolean isDone, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, Boolean isReminderEnabled, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.title = title;
         this.isDone = isDone;
         this.description = description;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
+        this.isReminderEnabled = isReminderEnabled;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -52,6 +55,7 @@ public class TaskEntity {
                 .description(task.getDescription())
                 .startDateTime(task.getTimeFrame().startDateTime())
                 .endDateTime(task.getTimeFrame().endDateTime())
+                .isReminderEnabled(task.isReminderEnabled())
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
                 .build();
@@ -64,6 +68,7 @@ public class TaskEntity {
                 .isDone(isDone)
                 .description(description)
                 .timeFrame(new TimeFrame(startDateTime, endDateTime))
+                .reminderEnabled(isReminderEnabled)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)
                 .build();

--- a/core/src/main/java/com/taskbuddy/core/database/repository/DefaultReminderSettingsRepository.java
+++ b/core/src/main/java/com/taskbuddy/core/database/repository/DefaultReminderSettingsRepository.java
@@ -1,0 +1,26 @@
+package com.taskbuddy.core.database.repository;
+
+import com.taskbuddy.core.domain.ReminderSettings;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+//임시생성
+@Repository
+public class DefaultReminderSettingsRepository implements ReminderSettingsRepository {
+
+    @Override
+    public Optional<ReminderSettings> findByTaskId(Long taskId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void save(ReminderSettings reminderSettings) {
+
+    }
+
+    @Override
+    public void deleteById(Long id) {
+
+    }
+}

--- a/core/src/main/java/com/taskbuddy/core/database/repository/ReminderSettingsRepository.java
+++ b/core/src/main/java/com/taskbuddy/core/database/repository/ReminderSettingsRepository.java
@@ -1,0 +1,14 @@
+package com.taskbuddy.core.database.repository;
+
+import com.taskbuddy.core.domain.ReminderSettings;
+
+import java.util.Optional;
+
+public interface ReminderSettingsRepository {
+
+    Optional<ReminderSettings> findByTaskId(Long taskId);
+
+    void save(ReminderSettings reminderSettings);
+
+    void deleteById(Long id);
+}

--- a/core/src/main/java/com/taskbuddy/core/domain/ReminderSettings.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/ReminderSettings.java
@@ -1,0 +1,66 @@
+package com.taskbuddy.core.domain;
+
+import com.taskbuddy.core.service.port.ClockHolder;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Getter
+public class ReminderSettings {
+    private final Long id;
+    private final Task task;
+    private LocalDateTime lastReminderSentTime;
+    private Duration reminderInterval;
+    private final LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public ReminderSettings(Long id, Task task, LocalDateTime lastReminderSentTime, Duration reminderInterval, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.task = task;
+        this.lastReminderSentTime = lastReminderSentTime;
+        this.reminderInterval = reminderInterval;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static ReminderSettings from(Task task, Duration reminderInterval, ClockHolder clockHolder) {
+        final LocalDateTime currentDateTime = clockHolder.currentDateTime();
+
+        return ReminderSettings.builder()
+                .task(task)
+                .reminderInterval(reminderInterval)
+                .createdAt(currentDateTime)
+                .updatedAt(currentDateTime)
+                .build();
+    }
+
+    public void updateLastReminderSentTime(LocalDateTime lastReminderSentTime, ClockHolder clockHolder) {
+        this.lastReminderSentTime = lastReminderSentTime;
+        this.updatedAt = clockHolder.currentDateTime();
+    }
+
+    public boolean isReminderDue(ClockHolder clockHolder) {
+        LocalDateTime currentDateTime = clockHolder.currentDateTime();
+        LocalDateTime taskStartDateTime = task.getTimeFrame().startDateTime();
+
+        if (currentDateTime.isBefore(taskStartDateTime)) {
+            return false;
+        }
+
+        Duration timeSinceStart = Duration.between(taskStartDateTime, currentDateTime);
+
+        return timeSinceStart.toMinutes() % reminderInterval.toMinutes() == 0;
+    }
+
+    public void updateReminderInterval(Duration reminderInterval, ClockHolder clockHolder) {
+        this.reminderInterval = reminderInterval;
+        this.updatedAt = clockHolder.currentDateTime();
+    }
+
+    public Long getTaskId() {
+        return task.getId();
+    }
+}

--- a/core/src/main/java/com/taskbuddy/core/domain/Task.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/Task.java
@@ -9,21 +9,24 @@ import java.time.LocalDateTime;
 @Getter
 public class Task {
     private final Long id;
-//    private User user;
+    private User user;
     private String title;
     private Boolean isDone;
     private String description;
     private TimeFrame timeFrame;
+    private boolean reminderEnabled;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     @Builder
-    public Task(Long id, String title, Boolean isDone, String description, TimeFrame timeFrame, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public Task(Long id, User user, String title, Boolean isDone, String description, TimeFrame timeFrame, boolean reminderEnabled, LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
+        this.user = user;
         this.title = title;
         this.isDone = isDone;
         this.description = description;
         this.timeFrame = timeFrame;
+        this.reminderEnabled = reminderEnabled;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -37,6 +40,7 @@ public class Task {
                 .isDone(isDoneDefaultValue)
                 .description(taskCreate.description())
                 .timeFrame(new TimeFrame(taskCreate.startDateTime(), taskCreate.endDateTime()))
+                .reminderEnabled(taskCreate.reminderEnabled())
                 .createdAt(createdAt)
                 .updatedAt(createdAt)
                 .build();
@@ -46,6 +50,7 @@ public class Task {
         title = taskContentUpdate.title();
         description = taskContentUpdate.description();
         timeFrame = new TimeFrame(taskContentUpdate.startDateTime(), taskContentUpdate.endDateTime());
+        reminderEnabled = taskContentUpdate.reminderEnabled();
         updatedAt = clockHolder.currentDateTime();
     }
 

--- a/core/src/main/java/com/taskbuddy/core/domain/TaskContentUpdate.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/TaskContentUpdate.java
@@ -7,6 +7,7 @@ public record TaskContentUpdate(
         Long userId,
         String title,
         String description,
+        Boolean reminderEnabled,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime
 ) {}

--- a/core/src/main/java/com/taskbuddy/core/domain/TaskContentUpdate.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/TaskContentUpdate.java
@@ -1,5 +1,6 @@
 package com.taskbuddy.core.domain;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 public record TaskContentUpdate(
@@ -8,6 +9,7 @@ public record TaskContentUpdate(
         String title,
         String description,
         Boolean reminderEnabled,
+        Duration reminderInterval,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime
 ) {}

--- a/core/src/main/java/com/taskbuddy/core/domain/TaskCreate.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/TaskCreate.java
@@ -6,6 +6,7 @@ public record TaskCreate (
         Long userId,
         String title,
         String description,
+        Boolean reminderEnabled,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime
 ) {}

--- a/core/src/main/java/com/taskbuddy/core/domain/TaskCreate.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/TaskCreate.java
@@ -1,5 +1,6 @@
 package com.taskbuddy.core.domain;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 public record TaskCreate (
@@ -7,6 +8,7 @@ public record TaskCreate (
         String title,
         String description,
         Boolean reminderEnabled,
+        Duration reminderInterval,
         LocalDateTime startDateTime,
         LocalDateTime endDateTime
 ) {}

--- a/core/src/main/java/com/taskbuddy/core/domain/User.java
+++ b/core/src/main/java/com/taskbuddy/core/domain/User.java
@@ -1,4 +1,14 @@
 package com.taskbuddy.core.domain;
 
-public record User(Long id) {
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class User {
+    private Long id;
+    private boolean loggedIn;
+    private boolean reminderEnabled;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
 }

--- a/core/src/main/java/com/taskbuddy/core/service/ReminderNotificationService.java
+++ b/core/src/main/java/com/taskbuddy/core/service/ReminderNotificationService.java
@@ -1,0 +1,48 @@
+package com.taskbuddy.core.service;
+
+import com.taskbuddy.core.domain.ReminderSettings;
+import com.taskbuddy.core.domain.Task;
+import com.taskbuddy.core.domain.User;
+import com.taskbuddy.core.service.port.ClockHolder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class ReminderNotificationService {
+    private final ReminderSettingsService reminderSettingsService;
+    private final UserService userService;
+//    private final NotificationService notificationService;
+    private final ClockHolder clockHolder;
+
+    public void sendNotification(Task task) {
+        User user = task.getUser();
+
+        // 1. 유저가 리마인드 알림설정이 켜져있는지 확인
+        if (!user.isReminderEnabled()) {
+            return; // 유저가 알림을 원하지 않으면 스킵
+        }
+
+        // 2. Task의 리마인드 설정이 켜져 있는지 확인
+        if (!task.isReminderEnabled()) {
+            return; // Task의 리마인드 설정이 꺼져 있으면 스킵
+        }
+
+        // 3. 리마인더주기에 맞는지 확인
+        ReminderSettings reminderSettings = reminderSettingsService.getByTaskId(task.getId());
+
+        // 마지막으로 알림을 보낼 시간이 리마인드 주기 이상일 경우에만 알림 전송
+        if (!reminderSettings.isReminderDue(clockHolder)) {
+            return; // 아직 리마인드 주기가 지나지 않았으므로 스킵
+        }
+
+        // 4. 유저가 현재 접속 중인지 확인 (접속 중이 아니면 리마인드)
+        if (!userService.isUserLoggedIn(user)) {
+            //리마인더 알림 전송
+//            notificationService.sendReminder(user, task);
+            reminderSettingsService.updateLastSentTime(reminderSettings, LocalDateTime.now());
+        }
+    }
+}

--- a/core/src/main/java/com/taskbuddy/core/service/ReminderSettingsService.java
+++ b/core/src/main/java/com/taskbuddy/core/service/ReminderSettingsService.java
@@ -1,0 +1,61 @@
+package com.taskbuddy.core.service;
+
+import com.taskbuddy.core.database.repository.ReminderSettingsRepository;
+import com.taskbuddy.core.domain.ReminderSettings;
+import com.taskbuddy.core.domain.Task;
+import com.taskbuddy.core.service.port.ClockHolder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class ReminderSettingsService {
+    private final ReminderSettingsRepository reminderSettingsRepository;
+    private final ClockHolder clockHolder;
+
+    public ReminderSettings getByTaskId(Long taskId) {
+        return reminderSettingsRepository.findByTaskId(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("Task Settings with given task id does not exist."));
+    }
+
+    public void initialize(Task task, Duration reminderInterval) {
+        if (!task.isReminderEnabled()) {
+            return;
+        }
+
+        ReminderSettings reminderSettings = ReminderSettings.from(task, reminderInterval);
+        reminderSettingsRepository.save(reminderSettings);
+    }
+
+    public void update(Task task, Duration reminderInterval) {
+        Optional<ReminderSettings> optionalReminderSettings = reminderSettingsRepository.findByTaskId(task.getId());
+
+        if (optionalReminderSettings.isEmpty()) {
+            initialize(task, reminderInterval);
+            return;
+        }
+
+        ReminderSettings reminderSettings = optionalReminderSettings.get();
+
+        if (!task.isReminderEnabled()) {
+            reminderSettingsRepository.deleteById(reminderSettings.getId());
+        } else {
+            reminderSettings.updateReminderInterval(reminderInterval, clockHolder);
+            reminderSettingsRepository.save(reminderSettings);
+        }
+    }
+
+    public void updateLastSentTime(ReminderSettings reminderSettings, LocalDateTime lastSentTime) {
+        reminderSettings.updateLastReminderSentTime(lastSentTime, clockHolder);
+    }
+
+    public void deleteByTaskId(Long taskId) {
+        reminderSettingsRepository.findByTaskId(taskId)
+                .ifPresent(reminderSettings -> reminderSettingsRepository.deleteById(reminderSettings.getId()));
+
+    }
+}

--- a/core/src/main/java/com/taskbuddy/core/service/ReminderSettingsService.java
+++ b/core/src/main/java/com/taskbuddy/core/service/ReminderSettingsService.java
@@ -22,12 +22,13 @@ public class ReminderSettingsService {
                 .orElseThrow(() -> new IllegalArgumentException("Task Settings with given task id does not exist."));
     }
 
+
     public void initialize(Task task, Duration reminderInterval) {
         if (!task.isReminderEnabled()) {
             return;
         }
 
-        ReminderSettings reminderSettings = ReminderSettings.from(task, reminderInterval);
+        ReminderSettings reminderSettings = ReminderSettings.from(task, reminderInterval, clockHolder);
         reminderSettingsRepository.save(reminderSettings);
     }
 
@@ -56,6 +57,5 @@ public class ReminderSettingsService {
     public void deleteByTaskId(Long taskId) {
         reminderSettingsRepository.findByTaskId(taskId)
                 .ifPresent(reminderSettings -> reminderSettingsRepository.deleteById(reminderSettings.getId()));
-
     }
 }

--- a/core/src/main/java/com/taskbuddy/core/service/ReminderSettingsService.java
+++ b/core/src/main/java/com/taskbuddy/core/service/ReminderSettingsService.java
@@ -22,7 +22,6 @@ public class ReminderSettingsService {
                 .orElseThrow(() -> new IllegalArgumentException("Task Settings with given task id does not exist."));
     }
 
-
     public void initialize(Task task, Duration reminderInterval) {
         if (!task.isReminderEnabled()) {
             return;

--- a/core/src/main/java/com/taskbuddy/core/service/TaskService.java
+++ b/core/src/main/java/com/taskbuddy/core/service/TaskService.java
@@ -43,6 +43,7 @@ public class TaskService {
         reminderSettingsService.update(task, taskContentUpdate.reminderInterval());
     }
 
+
     public void updateDone(TaskDoneUpdate taskDoneUpdate) {
         Task task = taskRepository.findById(taskDoneUpdate.id())
                 .orElseThrow(() -> new IllegalArgumentException("The given task with id does not exist."));
@@ -51,6 +52,7 @@ public class TaskService {
         taskRepository.save(task);
     }
 
+    @Transactional
     public void deleteTask(Long id) {
         final boolean exists = taskRepository.existsById(id);
 

--- a/core/src/main/java/com/taskbuddy/core/service/UserService.java
+++ b/core/src/main/java/com/taskbuddy/core/service/UserService.java
@@ -1,0 +1,13 @@
+package com.taskbuddy.core.service;
+
+import com.taskbuddy.core.domain.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    //임시 구현
+    public boolean isUserLoggedIn(User user) {
+        return user.isLoggedIn();
+    }
+}

--- a/core/src/test/java/com/taskbuddy/core/domain/ReminderSettingsTest.java
+++ b/core/src/test/java/com/taskbuddy/core/domain/ReminderSettingsTest.java
@@ -1,0 +1,154 @@
+package com.taskbuddy.core.domain;
+
+import com.taskbuddy.core.mock.TestClockHolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReminderSettingsTest {
+
+    @Test
+    void task와_reminderInterval로_ReminderSettings_객체를_생성할_수_있다() {
+        //given
+        Task mockTask = Mockito.mock(Task.class);
+        Mockito.when(mockTask.getId()).thenReturn(1L);
+
+        Duration givenReminderInterval = Duration.ofMinutes(10);
+
+        LocalDateTime createdDateTime = LocalDateTime.now();
+        TestClockHolder testClockHolder = new TestClockHolder(createdDateTime);
+
+        //when
+        ReminderSettings reminderSettings = ReminderSettings.from(mockTask, givenReminderInterval, testClockHolder);
+
+        //then
+        assertThat(reminderSettings).isNotNull();
+        assertThat(reminderSettings.getId()).isNull();
+        assertThat(reminderSettings.getTaskId()).isEqualTo(1L);
+        assertThat(reminderSettings.getReminderInterval()).isEqualTo(givenReminderInterval);
+        assertThat(reminderSettings.getLastReminderSentTime()).isNull();;
+        assertThat(reminderSettings.getCreatedAt()).isEqualTo(createdDateTime);
+        assertThat(reminderSettings.getUpdatedAt()).isEqualTo(createdDateTime);
+    }
+
+    @Test
+    void 최근발송일시를_업데이트할_수_있다() {
+        //given
+        LocalDateTime createdDateTime = LocalDateTime.now().minusDays(3);
+        LocalDateTime lastReminderSentTime = LocalDateTime.now().minusMinutes(20);
+        Duration reminderInterval = Duration.ofMinutes(20);
+
+        ReminderSettings reminderSettings = ReminderSettings.builder()
+                .id(1L)
+                .task(Task.builder().id(1L).build())
+                .lastReminderSentTime(lastReminderSentTime)
+                .reminderInterval(reminderInterval)
+                .createdAt(createdDateTime)
+                .updatedAt(createdDateTime)
+                .build();
+
+        LocalDateTime updatedLastSentTime = LocalDateTime.now();
+        LocalDateTime updatedDateTime = LocalDateTime.now();
+
+        //when
+        reminderSettings.updateLastReminderSentTime(updatedLastSentTime, new TestClockHolder(updatedDateTime));
+
+        //then
+        assertThat(reminderSettings.getId()).isEqualTo(1L);
+        assertThat(reminderSettings.getTaskId()).isEqualTo(1L);
+        assertThat(reminderSettings.getReminderInterval()).isEqualTo(reminderInterval);
+        assertThat(reminderSettings.getLastReminderSentTime()).isEqualTo(updatedLastSentTime);
+        assertThat(reminderSettings.getCreatedAt()).isEqualTo(createdDateTime);
+        assertThat(reminderSettings.getUpdatedAt()).isEqualTo(updatedDateTime);
+    }
+
+    @Test
+    void 현재일시가_Reminder_발송일시인지_여부를_반환한다() {
+        //given
+        LocalDateTime createdDateTime = LocalDateTime.now().minusDays(3);
+        LocalDateTime taskStartDateTime = LocalDate.now().atStartOfDay();
+        Task task = Task.builder()
+                .id(1L)
+                .reminderEnabled(true)
+                .timeFrame(new TimeFrame(taskStartDateTime, LocalDate.now().plusWeeks(1).atStartOfDay()))
+                .createdAt(createdDateTime)
+                .updatedAt(createdDateTime)
+                .build();
+
+        LocalDateTime lastReminderSentTime = LocalDateTime.now().minusMinutes(20);
+        Duration reminderInterval = Duration.ofMinutes(10);
+        ReminderSettings reminderSettings = ReminderSettings.builder()
+                .id(1L)
+                .task(task)
+                .lastReminderSentTime(lastReminderSentTime)
+                .reminderInterval(reminderInterval)
+                .createdAt(createdDateTime)
+                .updatedAt(createdDateTime)
+                .build();
+
+        //when & then
+        Assertions.assertAll(
+                () -> {
+                    LocalDateTime currentDateTime = taskStartDateTime;
+                    Assertions.assertTrue(reminderSettings.isReminderDue(new TestClockHolder(currentDateTime)));
+                },
+                () -> {
+                    LocalDateTime currentDateTime = taskStartDateTime.plusMinutes(10);
+                    Assertions.assertTrue(reminderSettings.isReminderDue(new TestClockHolder(currentDateTime)));
+                },
+                () -> {
+                    LocalDateTime currentDateTime = taskStartDateTime.plusMinutes(20);
+                    Assertions.assertTrue(reminderSettings.isReminderDue(new TestClockHolder(currentDateTime)));
+                },
+                () -> {
+                    LocalDateTime currentDateTime = taskStartDateTime.plusMinutes(30);
+                    Assertions.assertTrue(reminderSettings.isReminderDue(new TestClockHolder(currentDateTime)));
+                },
+                () -> {
+                    LocalDateTime currentDateTime = taskStartDateTime.plusMinutes(3);
+                    Assertions.assertFalse(reminderSettings.isReminderDue(new TestClockHolder(currentDateTime)));
+                },
+                () -> {
+                    LocalDateTime currentDateTime = taskStartDateTime.plusMinutes(22);
+                    Assertions.assertFalse(reminderSettings.isReminderDue(new TestClockHolder(currentDateTime)));
+                }
+        );
+    }
+
+    @Test
+    void ReminderInterval을_업데이트할_수_있다() {
+        //given
+        LocalDateTime createdDateTime = LocalDateTime.now().minusDays(3);
+        LocalDateTime lastReminderSentTime = LocalDateTime.now().minusMinutes(20);
+        Duration reminderInterval = Duration.ofMinutes(20);
+
+        ReminderSettings reminderSettings = ReminderSettings.builder()
+                .id(1L)
+                .task(Task.builder().id(1L).build())
+                .lastReminderSentTime(lastReminderSentTime)
+                .reminderInterval(reminderInterval)
+                .createdAt(createdDateTime)
+                .updatedAt(createdDateTime)
+                .build();
+
+        Duration updatedReminderInterval = Duration.ofHours(1);
+        LocalDateTime updatedDateTime = LocalDateTime.now();
+
+        //when
+        reminderSettings.updateReminderInterval(updatedReminderInterval, new TestClockHolder(updatedDateTime));
+
+        //then
+        assertThat(reminderSettings.getId()).isEqualTo(1L);
+        assertThat(reminderSettings.getTaskId()).isEqualTo(1L);
+        assertThat(reminderSettings.getReminderInterval()).isEqualTo(updatedReminderInterval);
+        assertThat(reminderSettings.getLastReminderSentTime()).isEqualTo(lastReminderSentTime);
+        assertThat(reminderSettings.getCreatedAt()).isEqualTo(createdDateTime);
+        assertThat(reminderSettings.getUpdatedAt()).isEqualTo(updatedDateTime);
+    }
+}

--- a/core/src/test/java/com/taskbuddy/core/domain/TaskTest.java
+++ b/core/src/test/java/com/taskbuddy/core/domain/TaskTest.java
@@ -3,6 +3,7 @@ package com.taskbuddy.core.domain;
 import com.taskbuddy.core.mock.TestClockHolder;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,6 +20,8 @@ class TaskTest {
                 1L,
                 "알고리즘 풀기",
                 "백준1902",
+                true,
+                Duration.ofMinutes(10),
                 LocalDateTime.of(2024, 8, 1, 0, 0, 0),
                 LocalDateTime.of(2024, 8, 31, 23, 59, 59));
 
@@ -64,6 +67,8 @@ class TaskTest {
                 1L,
                 "알고리즘 풀기",
                 "백준2630",
+                true,
+                Duration.ofMinutes(10),
                 LocalDateTime.of(2024, 9, 1, 0, 0, 0),
                 LocalDateTime.of(2024, 9, 30, 23, 59, 59));
 

--- a/core/src/test/java/com/taskbuddy/core/service/ReminderSettingsServiceTest.java
+++ b/core/src/test/java/com/taskbuddy/core/service/ReminderSettingsServiceTest.java
@@ -1,0 +1,117 @@
+package com.taskbuddy.core.service;
+
+import com.taskbuddy.core.database.repository.ReminderSettingsRepository;
+import com.taskbuddy.core.domain.ReminderSettings;
+import com.taskbuddy.core.domain.Task;
+import com.taskbuddy.core.mock.TestClockHolder;
+import com.taskbuddy.core.service.port.ClockHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+
+class ReminderSettingsServiceTest {
+    private ReminderSettingsService reminderSettingsService;
+    private ReminderSettingsRepository reminderSettingsRepository;
+    private ClockHolder clockHolder;
+
+    @BeforeEach
+    void setUp() {
+        reminderSettingsRepository = mock(ReminderSettingsRepository.class);
+        clockHolder = new TestClockHolder(LocalDateTime.now());
+
+        reminderSettingsService = new ReminderSettingsService(reminderSettingsRepository, clockHolder);
+    }
+
+    @Test
+    void Task의_ReminderEnabled가_false라면_초기화를_하지_않고_종료한다() {
+        //given
+        Task mockTask = mock(Task.class);
+        when(mockTask.isReminderEnabled()).thenReturn(false);
+
+        //when
+        reminderSettingsService.initialize(mockTask, null);
+
+        //then
+        verify(reminderSettingsRepository, never()).save(any(ReminderSettings.class));
+    }
+
+    @Test
+    void Task의_ReminderEnabled가_true라면_주어진_interval설정으로_초기화된다() {
+        //given
+        Task mockTask = mock(Task.class);
+        when(mockTask.isReminderEnabled()).thenReturn(true);
+
+        Duration givenReminderInterval = Duration.ofMinutes(10);
+
+        //when
+        reminderSettingsService.initialize(mockTask, givenReminderInterval);
+
+        //then
+        verify(reminderSettingsRepository, times(1)).save(any(ReminderSettings.class));
+    }
+
+    @Test
+    void 주어진_TaskId로_ReminderSettings가_존재하지_않는경우_새로_초기화한다() {
+        //given
+        Task mockTask = mock(Task.class);
+        when(mockTask.getId()).thenReturn(1L);
+        when(reminderSettingsRepository.findByTaskId(mockTask.getId())).thenReturn(Optional.empty());
+
+        Duration givenReminderInterval = Duration.ofMinutes(10);
+
+        ReminderSettingsService spyReminderSettingsService = spy(this.reminderSettingsService);
+
+        //when
+        spyReminderSettingsService.update(mockTask, givenReminderInterval);
+
+        //then
+        verify(spyReminderSettingsService, times(1)).initialize(mockTask, givenReminderInterval);
+        verify(reminderSettingsRepository, never()).save(any(ReminderSettings.class));
+        verify(reminderSettingsRepository, never()).deleteById(anyLong());
+    }
+
+    @Test
+    void 주어진_TaskId로_ReminderSettings가_존재하는데_Task의_reminder설정이_false일_경우_ReminderSettings를_삭제한다() {
+        //given
+        Task mockTask = mock(Task.class);
+        when(mockTask.getId()).thenReturn(1L);
+        when(mockTask.isReminderEnabled()).thenReturn(false);
+
+        ReminderSettings mockReminderSettings = mock(ReminderSettings.class);
+        when(reminderSettingsRepository.findByTaskId(mockTask.getId())).thenReturn(Optional.of(mockReminderSettings));
+
+        Duration givenReminderInterval = Duration.ofMinutes(10);
+
+        //when
+        reminderSettingsService.update(mockTask, givenReminderInterval);
+
+        //then
+        verify(reminderSettingsRepository, times(1)).deleteById(mockReminderSettings.getId());
+        verify(reminderSettingsRepository, never()).save(any(ReminderSettings.class));
+    }
+
+    @Test
+    void 주어진_TaskId로_ReminderSettings가_존재하면서_Task의_reminder설정이_true일_경우_ReminderInterval을_업데이트한다() {
+        //given
+        Task mockTask = mock(Task.class);
+        when(mockTask.getId()).thenReturn(1L);
+        when(mockTask.isReminderEnabled()).thenReturn(true);
+
+        ReminderSettings mockReminderSettings = mock(ReminderSettings.class);
+        when(reminderSettingsRepository.findByTaskId(mockTask.getId())).thenReturn(Optional.of(mockReminderSettings));
+
+        Duration givenReminderInterval = Duration.ofMinutes(10);
+
+        //when
+        reminderSettingsService.update(mockTask, givenReminderInterval);
+
+        //then
+        verify(mockReminderSettings, times(1)).updateReminderInterval(givenReminderInterval, clockHolder);
+        verify(reminderSettingsRepository, times(1)).save(mockReminderSettings);
+    }
+}

--- a/core/src/test/java/com/taskbuddy/core/service/TaskServiceTest.java
+++ b/core/src/test/java/com/taskbuddy/core/service/TaskServiceTest.java
@@ -82,6 +82,7 @@ class TaskServiceTest {
                 1L,
                 "알고리즘 문제 풀기",
                 "백준1902",
+                false,
                 LocalDateTime.of(2024, 8, 1, 0, 0, 0),
                 LocalDateTime.of(2024, 8, 31, 23, 59, 59));
 
@@ -150,6 +151,7 @@ class TaskServiceTest {
                 1L,
                 "알고리즘 문제 풀기",
                 "백준4300",
+                true,
                 LocalDateTime.of(2024, 9, 1, 0, 0, 0),
                 LocalDateTime.of(2024, 9, 10, 23, 59, 59));
 

--- a/core/src/test/java/com/taskbuddy/core/service/TaskServiceTest.java
+++ b/core/src/test/java/com/taskbuddy/core/service/TaskServiceTest.java
@@ -118,6 +118,7 @@ class TaskServiceTest {
                 1L,
                 "알고리즘 문제 풀기",
                 "백준4300",
+                true,
                 LocalDateTime.of(2024, 9, 1, 0, 0, 0),
                 LocalDateTime.of(2024, 9, 10, 23, 59, 59));
 

--- a/core/src/test/java/com/taskbuddy/core/service/TaskServiceTest.java
+++ b/core/src/test/java/com/taskbuddy/core/service/TaskServiceTest.java
@@ -133,7 +133,7 @@ class TaskServiceTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The given task with id does not exist.");
         Mockito.verify(taskRepository, Mockito.never()).save(Mockito.any(Task.class));
-
+        Mockito.verify(reminderSettingsService, Mockito.never()).initialize(Mockito.any(Task.class), Mockito.any());
     }
 
     @Test


### PR DESCRIPTION
## 배경
> 리마인더 알림 발송기능을 하기 전에 Task 등록시 알림 설정하는 부분이 필요할 것 같아 추가하였습니다. 
> Task 등록, 수정시 시작일시기준 몇분 단위마다 리마인더알림을 줄건지를 설정할 수 있도록 하였습니다.

### 알림 요구사항
> ReminderNotificationService.java 에서 구현 (일부만 구현됨)
- 유저의 리마인더 알림활성여부가 true여야한다. 
- Task의 리마인더 알림활성여부 true여야한다.
- Task가 진행중인데 유저가 미접속상태일 경우 ReminderInterval 단위로 알림을 발송한다. 

## 변경 내용
- Task 등록시 ReminderSettings(리마인더 설정) 초기화 (Task에 리마인더활성여부가 true인 경우) 추가
- Task 업데이트시 ReminderSettings 업데이트. 알림활성여부가 false이면 ReminderSettings 데이터 삭제, true이면 내용을 업데이트하도록 추가
- Task 삭제시 ReminderSettings 데이터삭제 추가

### 참고내용
이전 리뷰내용과 ClockHolder 내용은 아직 반영 전입니다..!  이번주중에 나누어서 반영하도록 하겠습니다. 🙂